### PR TITLE
Fix compatibility with minimal mode

### DIFF
--- a/skins/larry/headermini.css
+++ b/skins/larry/headermini.css
@@ -58,7 +58,7 @@
 }
 
 .minimal #topline a.button-logout {
-        display: inline_block;
+        display: inline-block;
 }
 
 .partwin #mainscreen,


### PR DESCRIPTION
Hi,
with roundcube 0.9.0 and Firefox 21.0, the `#mainscreen {...}` rule defined in headermini.css gets overriden by the `.minimal #mainscreen {...}` rule defined in styles.css. Thus there is a huge amount of space available between the topbar and the toolbar.
I fixed that and made the logout button visible.

Thanks for your plugin! Apart from that little issue, it was exactly what I needed.
