### PR TITLE
Fix toolbar space and button width

### DIFF
--- a/skins/larry/hidelabels.css
+++ b/skins/larry/hidelabels.css
@@ -24,8 +24,13 @@
         margin-top: 32px;
 }
 
+#mainscreencontent {
+        top: 0px;
+}
+
 #addressbooktoolbar a.button,
 #messagetoolbar a.button {
         color: transparent;
         text-shadow: none;
+        font-size: 0em;
 }


### PR DESCRIPTION
With version 1.1.1 of Roundcube there is emtpy space below the toolbar and unnecessary space between toolbar buttons if the labels are turn of. The patch should fix this.