### PR TITLE
Fix issue that is difficult to select quicksearchbar

### DIFF
--- a/skins/larry/hidelabels.css
+++ b/skins/larry/hidelabels.css
@@ -1,5 +1,6 @@
 #messagesearchtools {
         top: -3px;
+        z-index: 10;
 }
 
 #addressview-right #quicksearchbar {


### PR DESCRIPTION
There is an issue that we can hardly click the form of 'quicksearchbar' to input a query when to set $rcmail_config['larrymod_hidelabels'] to true.
I tested on Firefox 43 and Chrome 47.
The issue is caused as the result of concealing 'quicksearchbar' under 'mainscreencontent'.
So I set z-index of 'quicksearchbar' to 10 same as 'messagetoolbar'.