### PR TITLE
Fix top alignment issue in full message view

### DIFF
--- a/skins/larry/hidelabels.css
+++ b/skins/larry/hidelabels.css
@@ -13,7 +13,7 @@
 #mailboxcontainer,
 #compose-contacts,
 #compose-content,
-#mailview-top {
+#mailview-right {
         top: 32px;
 }
 


### PR DESCRIPTION
The message tool bar has an overlap with mail headers of message content pane in the full message view which is shown when we double-click a message in the mail list.
It is due to the issue that the message content pane (#mailview-right) is appropriately shifted downward as compared to the mail folders pane (#mailview-left).
The current implementation shifts #mailview-top downward to do this, but the full message view doesn't have the #mailview-top.