### PR TITLE
Fix an issue not to be able to click any tool on the message toolbar

### DIFF
--- a/skins/larry/hidelabels.css
+++ b/skins/larry/hidelabels.css
@@ -17,6 +17,10 @@
         top: 32px;
 }
 
+#messagetoolbar {
+        z-index: 10;
+}
+
 #messagetoolbar .toolbarselect {
         bottom: 12px;
 }
@@ -27,6 +31,7 @@
 
 #mainscreencontent {
         top: 0px;
+        z-index: 9;
 }
 
 #addressbooktoolbar a.button,


### PR DESCRIPTION
In Roundcube v1.3.3, when 'larrymod_hidelabels' is set,  all buttons on message toolbar cannot respond to clicking. It will be the problem about the order of z-index among 'messagetoolbar', 'mainscreencontent' and 'messagesearchtools'. 'mainscreencontent' has to be under the others. Thereby, I added 'z-index' properties in them. However, 'z-index' value of 'mainscreencontent' is just a quick hack.